### PR TITLE
use env to select sh

### DIFF
--- a/vpnsetup.sh
+++ b/vpnsetup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Script for automatic setup of an IPsec/L2TP VPN server on Ubuntu LTS and Debian 8.
 # Works on dedicated servers and any KVM- or Xen-based Virtual Private Server (VPS).

--- a/vpnsetup_centos.sh
+++ b/vpnsetup_centos.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Script for automatic setup of an IPsec/L2TP VPN server on 64-bit CentOS/RHEL 6 & 7.
 # Works on dedicated servers and any KVM- or Xen-based Virtual Private Server (VPS).

--- a/vpnupgrade_Libreswan.sh
+++ b/vpnupgrade_Libreswan.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Script to upgrade Libreswan on Ubuntu and Debian
 #

--- a/vpnupgrade_Libreswan_centos.sh
+++ b/vpnupgrade_Libreswan_centos.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Script to upgrade Libreswan on CentOS and RHEL
 #


### PR DESCRIPTION
Rather than using `/bin/sh` for the environment shell, it's better to defer it to the environmental shell by using `/usr/bin/env sh` to select the default shell. This will align with any updates that have been made to the system and ensure better compatibility with any users that have modified their systems respectively.