### PR TITLE
Add 3des-sha2 to both ike= and phase2alg= lines.

### DIFF
--- a/vpnsetup.sh
+++ b/vpnsetup.sh
@@ -244,8 +244,8 @@ conn shared
   dpddelay=30
   dpdtimeout=120
   dpdaction=clear
-  ike=3des-sha1,3des-sha1;modp1024,aes-sha1,aes-sha1;modp1024,aes-sha2,aes-sha2;modp1024,aes256-sha2_512
-  phase2alg=3des-sha1,aes-sha1,aes-sha2,aes256-sha2_512
+  ike=3des-sha1,3des-sha1;modp1024,aes-sha1,aes-sha1;modp1024,aes-sha2,aes-sha2;modp1024,aes256-sha2_512,3des-sha2
+  phase2alg=3des-sha1,aes-sha1,aes-sha2,aes256-sha2_512,3des-sha2
   sha2-truncbug=yes
 
 conn l2tp-psk

--- a/vpnsetup_centos.sh
+++ b/vpnsetup_centos.sh
@@ -230,8 +230,8 @@ conn shared
   dpddelay=30
   dpdtimeout=120
   dpdaction=clear
-  ike=3des-sha1,3des-sha1;modp1024,aes-sha1,aes-sha1;modp1024,aes-sha2,aes-sha2;modp1024,aes256-sha2_512
-  phase2alg=3des-sha1,aes-sha1,aes-sha2,aes256-sha2_512
+  ike=3des-sha1,3des-sha1;modp1024,aes-sha1,aes-sha1;modp1024,aes-sha2,aes-sha2;modp1024,aes256-sha2_512,3des-sha2
+  phase2alg=3des-sha1,aes-sha1,aes-sha2,aes256-sha2_512,3des-sha2
   sha2-truncbug=yes
 
 conn l2tp-psk


### PR DESCRIPTION
Fixes #154

This option was necessary to have Android 6.0 being able to connect to the IPSec VPN server