### PR TITLE
Fix multiple devices simultaneously cannot connect from behind the same NAT

### DIFF
--- a/vpnsetup_centos.sh
+++ b/vpnsetup_centos.sh
@@ -242,6 +242,8 @@ conn l2tp-psk
   type=transport
   phase2=esp
   also=shared
+  leftnexthop=%defaultroute
+  rightnexthop=%defaultroute
 
 conn xauth-psk
   auto=add
@@ -259,6 +261,8 @@ conn xauth-psk
   ikev2=never
   cisco-unity=yes
   also=shared
+  leftnexthop=%defaultroute
+  rightnexthop=%defaultroute
 EOF
 
 # Specify IPsec PSK


### PR DESCRIPTION
修复一个NAT下只能链接一个客户端问题.现在L2TP和XAUTH都可以在同一个内网中的多个设备同时登陆了.

Fix multiple devices cannot simultaneously connect from behind the same NAT. Now either L2TP or XAUTH can simultaneously connect from behind the same NAT.