### PR TITLE
Troubleshooting error 728

### DIFF
--- a/docs/clients-zh.md
+++ b/docs/clients-zh.md
@@ -379,7 +379,7 @@ strongswan down myvpn
   ```
 
 - 某些 Windows 系统默认禁用了 IPSec 加密, 此时也会导致连接失败. 可通过该命令启用 IPSec
-  ```console
+  ```console
   REG ADD HKLM\SYSTEM\CurrentControlSet\Services\RasMan\Parameters /v ProhibitIpSec /t REG_DWORD /d 0x0 /f
   ```
 

--- a/docs/clients-zh.md
+++ b/docs/clients-zh.md
@@ -18,7 +18,7 @@
   * [Windows Phone](#windows-phone)
   * [Linux](#linux)
 * [故障排除](#故障排除)
-  * [Windows 错误 809](#windows-错误-809)
+  * [Windows 错误 809 和 728](#windows-错误-809-和-728)
   * [Windows 错误 628](#windows-错误-628)
   * [Android 6 及以上版本](#android-6-及以上版本)
   * [Chromebook](#chromebook)
@@ -362,7 +362,7 @@ strongswan down myvpn
 
 *其他语言版本: [English](clients.md#troubleshooting), [简体中文](clients-zh.md#故障排除).*
 
-### Windows 错误 809
+### Windows 错误 809 和 728
 
 > 无法建立计算机与 VPN 服务器之间的网络连接，因为远程服务器未响应。
 
@@ -376,6 +376,11 @@ strongswan down myvpn
 - 仅适用于 Windows XP
   ```console
   REG ADD HKLM\SYSTEM\CurrentControlSet\Services\IPSec /v AssumeUDPEncapsulationContextOnSendRule /t REG_DWORD /d 0x2 /f
+  ```
+
+- 某些 Windows 系统默认禁用了 IPSec 加密, 此时也会导致连接失败. 可通过该命令启用 IPSec
+  ```console
+  REG ADD HKLM\SYSTEM\CurrentControlSet\Services\RasMan\Parameters /v ProhibitIpSec /t REG_DWORD /d 0x0 /f
   ```
 
 ### Windows 错误 628


### PR DESCRIPTION
遇到许多系统都是因为默认禁用了 IPSec 导致无法连接. 通过设置 ProhibitIpSec=0 注册表项即可解决.