### PR TITLE
Install iptables if it's not installed previously

### DIFF
--- a/vpnsetup.sh
+++ b/vpnsetup.sh
@@ -169,7 +169,7 @@ bigecho "Installing packages required for the VPN..."
 apt-get -yq install libnss3-dev libnspr4-dev pkg-config \
   libpam0g-dev libcap-ng-dev libcap-ng-utils libselinux1-dev \
   libcurl4-nss-dev flex bison gcc make libnss3-tools \
-  libevent-dev ppp xl2tpd || exiterr2
+  libevent-dev ppp xl2tpd iptables || exiterr2
 
 bigecho "Installing Fail2Ban to protect SSH..."
 


### PR DESCRIPTION
My brand new Debian 9 server hosted at Gandi.net doesn't have `iptables` installed.

I don't know if it's something related to Debian 9 or to Gandi.net, but it's great to also add the `iptables` dependency when installing the bunch of packages via `apt-get`. If it's not needed, at least it will showcase a dependency that the script actually has.

Hope it will save time to someone in the future! And thanks for your work!

By the way, some screenshots to show what happens when running the script in a host without `iptables`:

<img width="586" alt="screen shot 2018-04-19 at 23 42 33" src="https://user-images.githubusercontent.com/456499/39020196-a9982540-4434-11e8-87df-551e5435bf95.png">

<img width="433" alt="screen shot 2018-04-19 at 23 43 14" src="https://user-images.githubusercontent.com/456499/39020203-ad585786-4434-11e8-8e16-8f6d3f7bd454.png">

