### PR TITLE
Change VPN connection script

### DIFF
--- a/change-vpn-cron-info
+++ b/change-vpn-cron-info
@@ -1,4 +1,6 @@
 If you have a few VPN connections installed on your Linux and you need change VPN automatically - use change-vpn.sh script.
+Script changes VPN connection to random one from inactive list.
+If VPN connection is lost - script will active random VPN connection
 
 Every VPN should be named with prefix "VPN-", then script will be able to change it.
 Type bash change-vpn.sh to change vpn manually or create a CRON job:

--- a/change-vpn-cron-info
+++ b/change-vpn-cron-info
@@ -1,0 +1,6 @@
+Every VPN should be named with prefix "VPN-", then script will be able to change it.
+Type bash change-vpn.sh to change vpn manually or create a CRON job:
+
+* */4 * * * bash /home/USERNAME/change-vpn.sh > /dev/null 2>&1 # will change VPN every 4 hours
+20 */4 * * * bash /home/USERNAME/change-vpn.sh > /dev/null 2>&1 # will change VPN every 4 hours at 20-th minute
+20 * * * * bash /home/USERNAME/change-vpn.sh > /dev/null 2>&1 # will change VPN every hour at 20-th minute

--- a/change-vpn-cron-info
+++ b/change-vpn-cron-info
@@ -1,3 +1,5 @@
+If you have a few VPN connection installed on your Linux and you need change VPN automatically - use change-vpn.sh script.
+
 Every VPN should be named with prefix "VPN-", then script will be able to change it.
 Type bash change-vpn.sh to change vpn manually or create a CRON job:
 

--- a/change-vpn-cron-info
+++ b/change-vpn-cron-info
@@ -1,4 +1,4 @@
-If you have a few VPN connection installed on your Linux and you need change VPN automatically - use change-vpn.sh script.
+If you have a few VPN connections installed on your Linux and you need change VPN automatically - use change-vpn.sh script.
 
 Every VPN should be named with prefix "VPN-", then script will be able to change it.
 Type bash change-vpn.sh to change vpn manually or create a CRON job:

--- a/change-vpn.sh
+++ b/change-vpn.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+ACTIVE_VPN=`nmcli con show -a | grep 'vpn'`
+INACTIVE_VPNS=( $(nmcli con show | grep 'vpn.*-') )
+
+VPNS=()
+
+for index in ${!INACTIVE_VPNS[@]}
+do
+  if [[ ${INACTIVE_VPNS[$index]} == *"VPN-"* ]]; then
+    VPNS+=(${INACTIVE_VPNS[$index]})
+  fi
+done
+
+rand=$[$RANDOM % ${#VPNS[@]}]
+NEW_CONNECTION=${VPNS[$rand]}
+
+nmcli con down $ACTIVE_VPN
+
+sleep 15
+
+nmcli con up $NEW_CONNECTION


### PR DESCRIPTION

If you have a few VPN connections installed on your Linux and you need change VPN automatically - use change-vpn.sh script.
Script changes VPN connection to random one from inactive list.
If VPN connection is lost - script will active random VPN connection

Every VPN should be named with prefix "VPN-", then script will be able to change it.
Type bash change-vpn.sh to change vpn manually or create a CRON job:

# will change VPN every 4 hours
* */4 * * * bash /home/USERNAME/change-vpn.sh > /dev/null 2>&1 

# will change VPN every 4 hours at 20-th minute
20 */4 * * * bash /home/USERNAME/change-vpn.sh > /dev/null 2>&1 

# will change VPN every hour at 20-th minute
20 * * * * bash /home/USERNAME/change-vpn.sh > /dev/null 2>&1 