### PR TITLE
Step if strongswan service not found was added

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -544,6 +544,10 @@ Restart services:
 
 ```bash
 service strongswan restart
+
+# For Ubuntu 20.04 if strongswan service not found
+ipsec restart
+
 service xl2tpd restart
 ```
 


### PR DESCRIPTION
I'm added `ipsec restart` possibly step (with comment), because strongswan service was not added on my system.