### PR TITLE
Fix PowerShell Line Continuation in clients.md

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -69,8 +69,8 @@ Alternatively, instead of following the steps above, you may create the VPN conn
 # Disable persistent command history
 Set-PSReadlineOption –HistorySaveStyle SaveNothing
 # Create VPN connection
-Add-VpnConnection -Name 'My IPsec VPN' -ServerAddress 'Your VPN Server IP' ^
-  -L2tpPsk 'Your VPN IPsec PSK' -TunnelType L2tp -EncryptionLevel Required ^
+Add-VpnConnection -Name 'My IPsec VPN' -ServerAddress 'Your VPN Server IP' `
+  -L2tpPsk 'Your VPN IPsec PSK' -TunnelType L2tp -EncryptionLevel Required `
   -AuthenticationMethod Chap,MSChapv2 -Force -RememberCredential -PassThru
 # Ignore the data encryption warning (data is encrypted in the IPsec tunnel)
 ```


### PR DESCRIPTION
`cmd.exe` uses ^ whereas `powershell.exe` uses `
