### PR TITLE
Bump Python version to 3.12 in the AWS CloudFormation template

### DIFF
--- a/aws/cloudformation-template-ipsec.json
+++ b/aws/cloudformation-template-ipsec.json
@@ -348,7 +348,7 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Handler": "index.handler",
-                "Runtime": "python3.8",
+                "Runtime": "python3.12",
                 "Role": {
                     "Fn::GetAtt": [
                         "LambdaExecutionRole",
@@ -457,7 +457,7 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Handler": "index.handler",
-                "Runtime": "python3.8",
+                "Runtime": "python3.12",
                 "Role": {
                     "Fn::GetAtt": [
                         "LambdaExecutionRole",


### PR DESCRIPTION
## Issue:
Python 3.8's security support ends on 31 Oct 2024, which is a cause of AWS's "Action Required" email sent to users having AWS Lambda deployments for Python 3.8:

> We are contacting you as we have identified that your AWS Account currently has one or more AWS Lambda functions using the Python 3.8 runtime.
>
> We are ending support for Python 3.8 in Lambda on October 14, 2024. This follows Python 3.8 End-Of-Life (EOL) which is scheduled for October, 2024 [1].
>
> As described in the Lambda runtime support policy [2], end of support for language runtimes in Lambda happens in several stages. Starting on October 14, 2024, Lambda will no longer apply security patches and other updates to the Python 3.8 runtime used by Lambda functions, and functions using Python 3.8 will no longer be eligible for technical support. Also, Python 3.8 will no longer be available in the AWS Console, although you can still create and update functions that use Python 3.8 via AWS CloudFormation, the AWS CLI, AWS SAM, or other tools. Starting February 28, 2025, you will no longer be able to create new Lambda functions using the Python 3.8 runtime. Starting March 31, 2025, you will no longer be able to update existing functions using the Python 3.8 runtime.
>
> We recommend that you upgrade your existing Python 3.8 functions to the latest available Python runtime in Lambda before October 14, 2024.
>
> End of support does not impact function execution. Your functions will continue to run. However, they will be running on an unsupported runtime which is no longer maintained or patched by the AWS Lambda team.

Starting February 28, 2025, the current AWS CloudFormation config template will fail, as Python 3.8 will no longer be supported in the AWS Lambda.

## Proposed solution:
Bump of Python's version from 3.8 to 3.12 is the most straightforward solution that does not require any changes in the template.