### PR TITLE
Added steps to setup clients running Fedora and its derivatives.

### DIFF
--- a/docs/ikev2-howto.md
+++ b/docs/ikev2-howto.md
@@ -537,7 +537,7 @@ sudo chmod 600 ca.cer client.cer client.key
 >    sudo mv /path/to/client.key /etc/ipsec.d/private/
 >    ```
 >
->5.  **Apply SELinux Contexts (Only for distributions actively running SELinux)**
+>5.  **Apply SELinux Contexts (Only for distributions actively running SELinux, like Fedora)**
 >    
 >
 >    This final command updates the security context of the files, ensuring they are correctly labeled for use by the VPN service.
@@ -555,7 +555,7 @@ sudo chmod 600 ca.cer client.cer client.key
 >    ```
 >    sudo nm-connection-editor
 >    ```
->    Proceed with instructions given below. When you need to select the certificate and key files, you must provide the full paths to the files you just moved. You can press **`Ctrl+L`** in the file selection dialog to type the paths directly.
+>    Proceed with the instructions given below. When you need to select the certificate and key files, you must provide the full paths to the files you just moved. You can press **`Ctrl+L`** in the file selection dialog to type the paths directly.
 >
 >The paths, for your convenience, are:
 >

--- a/docs/ikev2-howto.md
+++ b/docs/ikev2-howto.md
@@ -435,19 +435,37 @@ Before configuring Linux VPN clients, you must make the following change on the 
 
 To configure your Linux computer to connect to IKEv2 as a VPN client, first install the strongSwan plugin for NetworkManager:
 
+##### Ubuntu and Debian
+
 ```bash
-# Ubuntu and Debian
 sudo apt-get update
 sudo apt-get install network-manager-strongswan
+```
 
-# Arch Linux
+##### Arch Linux
+
+```bash
 sudo pacman -Syu  # upgrade all packages
 sudo pacman -S networkmanager-strongswan
+```
 
-# Fedora
-sudo yum install NetworkManager-strongswan-gnome
+##### Fedora
 
-# CentOS
+
+For KDE Plasma/LXQt users:
+
+```bash
+sudo dnf install NetworkManager-strongswan-gnome plasma-nm-strongswan
+```
+Other DEs:
+```bash
+sudo dnf install NetworkManager-strongswan-gnome
+```
+
+
+##### CentOS
+
+```bash
 sudo yum install epel-release
 sudo yum --enablerepo=epel install NetworkManager-strongswan-gnome
 ```

--- a/docs/ikev2-howto.md
+++ b/docs/ikev2-howto.md
@@ -562,10 +562,6 @@ sudo chmod 600 ca.cer client.cer client.key
 >`/etc/ipsec.d/certs/` & `/etc/ipsec.d/private/`
 ></details>
 
->[!TIP]
-> If you're using the KDE Plasma desktop, you might encounter issues when configuring the VPN through the graphical System Settings. To ensure a smooth setup, we recommend launching the dedicated connection editor instead by running `sudo nm-connection-editor` in a terminal.
-
-
 You can then set up and enable the VPN connection:
 
 1. Go to Settings -> Network -> VPN. Click the **+** button.
@@ -583,6 +579,11 @@ You can then set up and enable the VPN connection:
 1. Enter `aes128gcm16` in the **ESP** field.
 1. Click **Add** to save the VPN connection information.
 1. Turn the **VPN** switch ON.
+
+
+>[!TIP]
+> If you're using the KDE Plasma desktop, you might encounter issues when configuring the VPN through the graphical System Settings. To ensure a smooth setup, we recommend launching the dedicated connection editor instead by running `sudo nm-connection-editor` in a terminal.
+
 
 Alternatively, you may connect using the command line. See [#1399](https://github.com/hwdsl2/setup-ipsec-vpn/issues/1399) and [#1007](https://github.com/hwdsl2/setup-ipsec-vpn/issues/1007) for example steps. If you encounter error `Could not find source connection`, edit `/etc/netplan/01-netcfg.yaml` and replace `renderer: networkd` with `renderer: NetworkManager`, then run `sudo netplan apply`. To connect to the VPN, run `sudo nmcli c up VPN`. To disconnect: `sudo nmcli c down VPN`.
 

--- a/docs/ikev2-howto.md
+++ b/docs/ikev2-howto.md
@@ -490,6 +490,81 @@ rm vpnclient.p12
 sudo chown root:root ca.cer client.cer client.key
 sudo chmod 600 ca.cer client.cer client.key
 ```
+>[!IMPORTANT]
+>
+>Clients running **Fedora** and its derivatives require a few extra steps to setup due to their default security policies.
+><details markdown="1">
+><summary>For <b>Fedora/Nobara 39+</b> clients:</summary>
+><br>
+>
+>
+>1.  **Enable SHA1 Support**
+>
+>    Modern Fedora versions disable certain legacy cryptographic algorithms, including SHA-1, which is used by this script to generate client certificates and keys. Re-enable support for SHA1-signed certificates by running:
+>
+>    ```
+>    sudo update-crypto-policies --set DEFAULT:SHA1
+>    ```
+>    **Reboot your system** after running this command.
+>
+>2.  **Set Secure File Ownership**
+>
+>    Fedora requires keys and certificates to be owned by root. Use the `chown` command to do so.
+>
+>    ```
+>    sudo chown root:root ca.cer client.cer client.key
+>    ```
+>
+>3.  **Create System Directories**
+>
+>    Create the official directories where the strongSwan service looks for certificates and private keys.
+>
+>    ```
+>    sudo mkdir -p /etc/ipsec.d/{certs,private}
+>    ```
+>
+>4.  **Move Files into Place**
+>
+>    Move the certificate and key files from your current location into the newly created system directories.
+>
+>    <br>
+>
+>    ```
+>    # Move certificates
+>    sudo mv /path/to/ca.cer /path/to/client.cer /etc/ipsec.d/certs/
+>
+>    # Move private key
+>    sudo mv /path/to/client.key /etc/ipsec.d/private/
+>    ```
+>
+>5.  **Apply SELinux Contexts (Only for distributions actively running SELinux)**
+>    
+>
+>    This final command updates the security context of the files, ensuring they are correctly labeled for use by the VPN service.
+>>⚠️
+>> **Do NOT run the following command on Nobara.**
+>
+>    ```
+>    sudo restorecon -R -v /etc/ipsec.d/
+>    ```
+>
+>5.  **Continue to NetworkManager Setup**
+>
+>    You are now ready to configure the connection using the graphical editor. Open it with:
+>
+>    ```
+>    sudo nm-connection-editor
+>    ```
+>    Proceed with instructions given below. When you need to select the certificate and key files, you must provide the full paths to the files you just moved. You can press **`Ctrl+L`** in the file selection dialog to type the paths directly.
+>
+>The paths, for your convenience, are:
+>
+>`/etc/ipsec.d/certs/` & `/etc/ipsec.d/private/`
+></details>
+
+>[!TIP]
+> If you're using the KDE Plasma desktop, you might encounter issues when configuring the VPN through the graphical System Settings. To ensure a smooth setup, we recommend launching the dedicated connection editor instead by running `sudo nm-connection-editor` in a terminal.
+
 
 You can then set up and enable the VPN connection:
 

--- a/docs/ikev2-howto.md
+++ b/docs/ikev2-howto.md
@@ -435,21 +435,21 @@ Before configuring Linux VPN clients, you must make the following change on the 
 
 To configure your Linux computer to connect to IKEv2 as a VPN client, first install the strongSwan plugin for NetworkManager:
 
-##### Ubuntu and Debian
+#### Ubuntu and Debian
 
 ```bash
 sudo apt-get update
 sudo apt-get install network-manager-strongswan
 ```
 
-##### Arch Linux
+#### Arch Linux
 
 ```bash
 sudo pacman -Syu  # upgrade all packages
 sudo pacman -S networkmanager-strongswan
 ```
 
-##### Fedora
+#### Fedora
 
 
 For KDE Plasma/LXQt users:
@@ -463,7 +463,7 @@ sudo dnf install NetworkManager-strongswan-gnome
 ```
 
 
-##### CentOS
+#### CentOS
 
 ```bash
 sudo yum install epel-release

--- a/docs/ikev2-howto.md
+++ b/docs/ikev2-howto.md
@@ -492,75 +492,79 @@ sudo chmod 600 ca.cer client.cer client.key
 ```
 >[!IMPORTANT]
 >
->Clients running **Fedora** and its derivatives require a few extra steps to setup due to their default security policies.
+>**_Fedora_** and its derivatives require a few extra steps to setup due to their default security policies.
 ><details markdown="1">
 ><summary>For <b>Fedora/Nobara 39+</b> clients:</summary>
 ><br>
 >
 >
->1.  **Enable SHA1 Support**
+>## 1. Enable SHA1 Support
 >
->    Modern Fedora versions disable certain legacy cryptographic algorithms, including SHA-1, which is used by this script to generate client certificates and keys. Re-enable support for SHA1-signed certificates by running:
+>Fedora 39+ disables SHA-1 cryptographic support by default. Since this VPN setup uses SHA-1 for certificate generation, you need to re-enable it system-wide. Run the following command:
 >
->    ```
->    sudo update-crypto-policies --set DEFAULT:SHA1
->    ```
->    **Reboot your system** after running this command.
->
->2.  **Set Secure File Ownership**
->
->    Fedora requires keys and certificates to be owned by root. Use the `chown` command to do so.
->
->    ```
->    sudo chown root:root ca.cer client.cer client.key
->    ```
->
->3.  **Create System Directories**
->
->    Create the official directories where the strongSwan service looks for certificates and private keys.
->
->    ```
->    sudo mkdir -p /etc/ipsec.d/{certs,private}
->    ```
->
->4.  **Move Files into Place**
->
->    Move the certificate and key files from your current location into the newly created system directories.
->
->    <br>
->
->    ```
->    # Move certificates
->    sudo mv /path/to/ca.cer /path/to/client.cer /etc/ipsec.d/certs/
->
->    # Move private key
->    sudo mv /path/to/client.key /etc/ipsec.d/private/
->    ```
->
->5.  **Apply SELinux Contexts (Only for distributions actively running SELinux, like Fedora)**
+>```
+>sudo update-crypto-policies --set DEFAULT:SHA1
+>```
+>**<ins>Reboot your system</ins>** after running this command. <br/>
 >    
+>## 2. Set Secure File Ownership
 >
->    This final command updates the security context of the files, ensuring they are correctly labeled for use by the VPN service.
->>⚠️
->> **Do NOT run the following command on Nobara.**
+>Fedora systems require that certificate and key files be owned by root. You can set the correct ownership using the `chown` command.
 >
->    ```
+>```
+>sudo chown root:root ca.cer client.cer client.key
+>```
+>
+>## 3. Create System Directories
+>
+>Create the official directories where the strongSwan service looks for certificates and private keys.
+>
+>```
+>sudo mkdir -p /etc/ipsec.d/{certs,private}
+>```
+>
+>## 4. Move Files into Place
+>
+>Move the certificate and key files from your current location into the newly created system directories.
+>
+>
+>```
+># Move certificates
+>sudo mv /path/to/ca.cer /path/to/client.cer /etc/ipsec.d/certs/
+>
+># Move private key
+>sudo mv /path/to/client.key /etc/ipsec.d/private/
+>```
+>
+>## 5. Apply SELinux Contexts (If SELinux is Active)
+>    
+>This command updates the security context of the files, ensuring they are correctly labeled for use by the VPN service. It will only run if SELinux is enabled on your system (_à la_ Fedora).
+>
+>```bash
+> bash -c '
+># Check if SELinux is enabled and apply contexts if necessary
+>if command -v sestatus >/dev/null 2>&1 && sestatus | grep -q "SELinux status:.*enabled"; then
 >    sudo restorecon -R -v /etc/ipsec.d/
->    ```
+>    echo "SELinux contexts applied successfully. Proceed to step 6."
+>else
+>    echo "SELinux not active or not found - skipping context restoration. Proceed to step 6."
+>fi'
+>```
 >
->5.  **Continue to NetworkManager Setup**
+>## 6. Continue to NetworkManager Setup
 >
->    You are now ready to configure the connection using the graphical editor. Open it with:
+>You are now ready to configure the connection using the graphical editor. Open it with:
 >
->    ```
->    sudo nm-connection-editor
->    ```
->    Proceed with the instructions given below. When you need to select the certificate and key files, you must provide the full paths to the files you just moved. You can press **`Ctrl+L`** in the file selection dialog to type the paths directly.
+>```
+>sudo nm-connection-editor
+>```
+>Proceed with the general Linux instructions below. When prompted to select certificate and key files during setup, use the files you just transferred to `/etc/ipsec.d/`. (Press **`Ctrl+L`** in the file picker to type the full paths directly.)
 >
 >The paths, for your convenience, are:
 >
 >`/etc/ipsec.d/certs/` & `/etc/ipsec.d/private/`
 ></details>
+
 
 You can then set up and enable the VPN connection:
 


### PR DESCRIPTION
I believe I've found a solution for the recurring issue where Fedora/Nobara users are asked for a private key password even when one isn't set (see #1464 , #1202 ).

My testing on Fedora 41 and Nobara 41 points to a combination of two root causes: Fedora 39's deprecation of SHA-1 and SELinux denying access to the certificate files due to incorrect security contexts.

I have created a detailed guide to walk users through the fix. The main trade-off is that it requires re-enabling SHA-1 support, which slightly lowers the system's default security settings in contrast to the Fedora project's recommendations.