### PR TITLE
Update CloudFormation Template

### DIFF
--- a/aws/README-zh.md
+++ b/aws/README-zh.md
@@ -14,7 +14,7 @@
 > 比如 `m5a.large` 可能无法在 `ap-east-1` 区域部署（仅为假设）。在此情况下，你会在部署过程中遇到此错误：`The requested configuration is currently not supported. Please check the documentation for supported configurations`。新开放的 AWS 区域更容易出现此问题，因为它们提供的实例类型较少。如需了解更多关于实例可用性的信息，请参见 [instances.vantage.sh](https://instances.vantage.sh/)。
 > </details>
 
-- VPN 服务器的操作系统（Ubuntu **24.04**/22.04, Debian 12/11, Amazon Linux 2）
+- VPN 服务器的操作系统（Ubuntu **26.04**/24.04/22.04, Debian 13/12/11, Amazon Linux 2）
 - 你的 VPN 用户名
 - 你的 VPN 密码
 - 你的 VPN IPsec PSK（预共享密钥）

--- a/aws/README.md
+++ b/aws/README.md
@@ -15,7 +15,7 @@ Available customization parameters:
 > For example, you may not be able to deploy an `m5a.large` instance in `ap-east-1` (hypothetically), in which case you might experience the following error during deployment: `The requested configuration is currently not supported. Please check the documentation for supported configurations`. Newly released regions are more prone to having this problem as there are less variety of instances. For more information about instance type availability, please refer to [instances.vantage.sh/](https://instances.vantage.sh).
 > </details>
 
-- OS for your VPN server (Ubuntu **24.04**/22.04, Debian 12/11, Amazon Linux 2)
+- OS for your VPN server (Ubuntu **26.04**/24.04/22.04, Debian 13/12/11, Amazon Linux 2)
 - Your VPN username
 - Your VPN password
 - Your VPN IPsec PSK (pre-shared key)

--- a/aws/cloudformation-template-ipsec.json
+++ b/aws/cloudformation-template-ipsec.json
@@ -628,7 +628,7 @@
         },
         "OS": {
             "Type": "String",
-            "Description": "The OS of your VPN server. Default: Ubuntu 24.04",
+            "Description": "The OS of your VPN server. Default: Ubuntu 26.04",
             "Default": "Ubuntu2604",
             "AllowedValues": [
                 "Ubuntu2604",

--- a/aws/cloudformation-template-ipsec.json
+++ b/aws/cloudformation-template-ipsec.json
@@ -30,10 +30,16 @@
             "Ubuntu2404": {
                 "HelperInstallationCommands": "export DEBIAN_FRONTEND=noninteractive\nrm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED\napt-get -yq update\napt-get -yq install python3-pip zip\nsnap install aws-cli --classic\npython3 -m pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
             },
+            "Ubuntu2604": {
+                "HelperInstallationCommands": "export DEBIAN_FRONTEND=noninteractive\nrm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED\napt-get -yq update\napt-get -yq install python3-pip zip\nsnap install aws-cli --classic\npython3 -m pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
+            },
             "Debian11": {
                 "HelperInstallationCommands": "export DEBIAN_FRONTEND=noninteractive\napt-get -yq update\napt-get -yq install python3-pip zip awscli\npython3 -m pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
             },
             "Debian12": {
+                "HelperInstallationCommands": "export DEBIAN_FRONTEND=noninteractive\nrm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED\napt-get -yq update\napt-get -yq install python3-pip zip awscli\npython3 -m pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
+            },
+            "Debian13": {
                 "HelperInstallationCommands": "export DEBIAN_FRONTEND=noninteractive\nrm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED\napt-get -yq update\napt-get -yq install python3-pip zip awscli\npython3 -m pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
             },
             "AmazonLinux2": {
@@ -481,8 +487,10 @@
                                 "       AMIName = {",
                                 "           'Ubuntu2204': 'ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*',",
                                 "           'Ubuntu2404': 'ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*',",
+                                "           'Ubuntu2604': 'ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-*',",
                                 "           'Debian11': 'debian-11-amd64-*',",
                                 "           'Debian12': 'debian-12-amd64-*',",
+                                "           'Debian13': 'debian-13-amd64-*',",
                                 "           'AmazonLinux2': 'amzn2-ami-hvm-*.*-x86_64-gp2',",
                                 "       }[distribution]",
                                 "       response = ec2.describe_images(Filters=[{'Name':'name', 'Values':[AMIName]}], Owners=['099720109477', '136693071363', 'amazon'])",
@@ -621,10 +629,12 @@
         "OS": {
             "Type": "String",
             "Description": "The OS of your VPN server. Default: Ubuntu 24.04",
-            "Default": "Ubuntu2404",
+            "Default": "Ubuntu2604",
             "AllowedValues": [
+                "Ubuntu2604",
                 "Ubuntu2404",
                 "Ubuntu2204",
+                "Debian13",
                 "Debian12",
                 "Debian11",
                 "AmazonLinux2"


### PR DESCRIPTION
Add Ubuntu 26.04 and Debian 13 support.

I was trying to add IPv6 support but since that address cannot be displayed post-deployment, I decide to at the moment not to make this change.

New OS(es) have been tested.