### PR TITLE
Update Libreswan to 5.3.2

### DIFF
--- a/.github/workflows/test_set_1.yml
+++ b/.github/workflows/test_set_1.yml
@@ -519,7 +519,7 @@ jobs:
           cp -f /opt/src/scripts/extras/vpnupgrade.sh ./vpnup.sh
           sed -i '/curl /a sed -i "/swan_ver_latest=/s/^/#/" "$tmpdir/vpnup.sh"' vpnup.sh
 
-          ver=5.3
+          ver=5.3.1
           sed -i "s/^SWAN_VER=.*/SWAN_VER=$ver/" vpnup.sh
           bash vpnup.sh <<ANSWERS
 
@@ -533,7 +533,7 @@ jobs:
           cp -f /opt/src/scripts/extras/vpnupgrade_centos.sh ./vpnup.sh
           sed -i '/swan_ver_latest=/s/^/#/' vpnup.sh
 
-          ver=5.3.1
+          ver=5.3.2
           bash vpnup.sh <<ANSWERS
 
           ANSWERS

--- a/.github/workflows/test_set_2.yml
+++ b/.github/workflows/test_set_2.yml
@@ -498,7 +498,7 @@ jobs:
           cp -f "$GITHUB_WORKSPACE"/extras/vpnupgrade.sh ./vpnup.sh
           sed -i '/curl /a sed -i "/swan_ver_latest=/s/^/#/" "$tmpdir/vpnup.sh"' vpnup.sh
 
-          ver=5.3
+          ver=5.3.1
           if [ "$os_type" = "alpine" ] || [ "$os_ver" = "trixiesid" ] || [ "$os_ver" = 13 ] \
             || [ "$os_ver" = "forkysid" ] || [ "$os_ver" = 14 ]; then
             ipsec whack --shutdown || true
@@ -520,7 +520,7 @@ jobs:
           fi
           sed -i '/swan_ver_latest=/s/^/#/' vpnup.sh
 
-          ver=5.3.1
+          ver=5.3.2
           if [ "$os_type" = "alpine" ] || [ "$os_ver" = "trixiesid" ] || [ "$os_ver" = 13 ] \
             || [ "$os_ver" = "forkysid" ] || [ "$os_ver" = 14 ]; then
             ipsec whack --shutdown || true

--- a/README-ja.md
+++ b/README-ja.md
@@ -373,7 +373,7 @@ https://gitlab.com/hwdsl2/setup-ipsec-vpn/-/raw/master/extras/vpnupgrade.sh
 ダウンロードできない場合は、[vpnupgrade.sh](extras/vpnupgrade.sh)を開き、右側の`Raw`ボタンをクリックします。`Ctrl/Cmd+A`を押してすべて選択し、`Ctrl/Cmd+C`を押してコピーし、お気に入りのエディタに貼り付けます。
 </details>
 
-最新のサポートされているLibreswanバージョンは`5.3.1`です。インストールされているバージョンを確認します：`ipsec --version`。
+最新のサポートされているLibreswanバージョンは`5.3.2`です。インストールされているバージョンを確認します：`ipsec --version`。
 
 **注:** `xl2tpd`は、Ubuntu/Debianの`apt-get`などのシステムのパッケージマネージャーを使用して更新できます。
 

--- a/README-ru.md
+++ b/README-ru.md
@@ -373,7 +373,7 @@ https://gitlab.com/hwdsl2/setup-ipsec-vpn/-/raw/master/extras/vpnupgrade.sh
 Если вы не можете скачать файл, откройте [vpnupgrade.sh](extras/vpnupgrade.sh), затем нажмите кнопку `Raw` справа. Нажмите `Ctrl/Cmd+A`, чтобы выделить всё, `Ctrl/Cmd+C`, чтобы скопировать, затем вставьте в ваш любимый редактор.
 </details>
 
-Последняя поддерживаемая версия Libreswan — `5.3.1`. Проверить установленную версию: `ipsec --version`.
+Последняя поддерживаемая версия Libreswan — `5.3.2`. Проверить установленную версию: `ipsec --version`.
 
 **Примечание:** `xl2tpd` можно обновить с помощью менеджера пакетов вашей системы, например `apt-get` в Ubuntu/Debian.
 

--- a/README-zh-Hant.md
+++ b/README-zh-Hant.md
@@ -373,7 +373,7 @@ https://gitlab.com/hwdsl2/setup-ipsec-vpn/-/raw/master/extras/vpnupgrade.sh
 如果無法下載，打開 [vpnupgrade.sh](extras/vpnupgrade.sh)，然後點擊右側的 `Raw` 按鈕。按快捷鍵 `Ctrl/Cmd+A` 全選，`Ctrl/Cmd+C` 複製，然後貼上到你喜歡的編輯器。
 </details>
 
-目前支援的 Libreswan 最新版本是 `5.3.1`。查看已安裝版本：`ipsec --version`。
+目前支援的 Libreswan 最新版本是 `5.3.2`。查看已安裝版本：`ipsec --version`。
 
 **註：** `xl2tpd` 可以使用系統的套件管理器進行更新，例如 Ubuntu/Debian 上的 `apt-get`。
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -373,7 +373,7 @@ https://gitlab.com/hwdsl2/setup-ipsec-vpn/-/raw/master/extras/vpnupgrade.sh
 如果无法下载，打开 [vpnupgrade.sh](extras/vpnupgrade.sh)，然后点击右边的 `Raw` 按钮。按快捷键 `Ctrl/Cmd+A` 全选，`Ctrl/Cmd+C` 复制，然后粘贴到你喜欢的编辑器。
 </details>
 
-当前支持的 Libreswan 最新版本是 `5.3.1`。查看已安装版本：`ipsec --version`。
+当前支持的 Libreswan 最新版本是 `5.3.2`。查看已安装版本：`ipsec --version`。
 
 **注：** `xl2tpd` 可以使用系统的软件包管理器进行更新，例如 Ubuntu/Debian 上的 `apt-get`。
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ https://gitlab.com/hwdsl2/setup-ipsec-vpn/-/raw/master/extras/vpnupgrade.sh
 If you are unable to download, open [vpnupgrade.sh](extras/vpnupgrade.sh), then click the `Raw` button on the right. Press `Ctrl/Cmd+A` to select all, `Ctrl/Cmd+C` to copy, then paste into your favorite editor.
 </details>
 
-The latest supported Libreswan version is `5.3.1`. Check installed version: `ipsec --version`.
+The latest supported Libreswan version is `5.3.2`. Check installed version: `ipsec --version`.
 
 **Note:** `xl2tpd` can be updated using your system's package manager, such as `apt-get` on Ubuntu/Debian.
 

--- a/extras/vpnupgrade_alpine.sh
+++ b/extras/vpnupgrade_alpine.sh
@@ -66,7 +66,7 @@ EOF
 }
 
 get_swan_ver() {
-  swan_ver_cur=5.3.1
+  swan_ver_cur=5.3.2
   base_url="https://github.com/hwdsl2/vpn-extras/releases/download/v1.0.0"
   swan_ver_url="$base_url/upg-v1-$os_type-$os_ver-swanver"
   swan_ver_latest=$(wget -t 2 -T 10 -qO- "$swan_ver_url" | head -n 1)

--- a/extras/vpnupgrade_amzn.sh
+++ b/extras/vpnupgrade_amzn.sh
@@ -52,7 +52,7 @@ EOF
 }
 
 get_swan_ver() {
-  swan_ver_cur=5.3.1
+  swan_ver_cur=5.3.2
   base_url="https://github.com/hwdsl2/vpn-extras/releases/download/v1.0.0"
   swan_ver_url="$base_url/upg-v1-amzn-2-swanver"
   swan_ver_latest=$(wget -t 2 -T 10 -qO- "$swan_ver_url" | head -n 1)

--- a/extras/vpnupgrade_centos.sh
+++ b/extras/vpnupgrade_centos.sh
@@ -89,7 +89,7 @@ EOF
 }
 
 get_swan_ver() {
-  swan_ver_cur=5.3.1
+  swan_ver_cur=5.3.2
   base_url="https://github.com/hwdsl2/vpn-extras/releases/download/v1.0.0"
   swan_ver_url="$base_url/upg-v1-$os_type-$os_ver-swanver"
   swan_ver_latest=$(wget -t 2 -T 10 -qO- "$swan_ver_url" | head -n 1)

--- a/extras/vpnupgrade_ubuntu.sh
+++ b/extras/vpnupgrade_ubuntu.sh
@@ -81,7 +81,7 @@ EOF
 }
 
 get_swan_ver() {
-  swan_ver_cur=5.3.1
+  swan_ver_cur=5.3.2
   base_url="https://github.com/hwdsl2/vpn-extras/releases/download/v1.0.0"
   swan_ver_url="$base_url/upg-v1-$os_type-$os_ver-swanver"
   swan_ver_latest=$(wget -t 2 -T 10 -qO- "$swan_ver_url" | head -n 1)

--- a/vpnsetup_alpine.sh
+++ b/vpnsetup_alpine.sh
@@ -258,7 +258,7 @@ get_helper_scripts() {
 }
 
 get_swan_ver() {
-  SWAN_VER=5.3.1
+  SWAN_VER=5.3.2
   base_url="https://github.com/hwdsl2/vpn-extras/releases/download/v1.0.0"
   swan_ver_url="$base_url/v1-$os_type-$os_ver-swanver"
   swan_ver_latest=$(wget -t 2 -T 10 -qO- "$swan_ver_url" | head -n 1)

--- a/vpnsetup_amzn.sh
+++ b/vpnsetup_amzn.sh
@@ -276,7 +276,7 @@ get_helper_scripts() {
 }
 
 get_swan_ver() {
-  SWAN_VER=5.3.1
+  SWAN_VER=5.3.2
   base_url="https://github.com/hwdsl2/vpn-extras/releases/download/v1.0.0"
   swan_ver_url="$base_url/v1-amzn-2-swanver"
   swan_ver_latest=$(wget -t 2 -T 10 -qO- "$swan_ver_url" | head -n 1)

--- a/vpnsetup_centos.sh
+++ b/vpnsetup_centos.sh
@@ -430,7 +430,7 @@ get_helper_scripts() {
 }
 
 get_swan_ver() {
-  SWAN_VER=5.3.1
+  SWAN_VER=5.3.2
   base_url="https://github.com/hwdsl2/vpn-extras/releases/download/v1.0.0"
   swan_ver_url="$base_url/v1-$os_type-$os_ver-swanver"
   swan_ver_latest=$(wget -t 2 -T 10 -qO- "$swan_ver_url" | head -n 1)

--- a/vpnsetup_ubuntu.sh
+++ b/vpnsetup_ubuntu.sh
@@ -344,7 +344,7 @@ get_helper_scripts() {
 }
 
 get_swan_ver() {
-  SWAN_VER=5.3.1
+  SWAN_VER=5.3.2
   base_url="https://github.com/hwdsl2/vpn-extras/releases/download/v1.0.0"
   swan_ver_url="$base_url/v1-$os_type-$os_ver-swanver"
   swan_ver_latest=$(wget -t 2 -T 10 -qO- "$swan_ver_url" | head -n 1)


### PR DESCRIPTION
### Motivation

- Bump the default Libreswan release and related references from `5.3.1` to `5.3.2` to follow the established one-step release progression used previously. 
- Keep upgrade helpers, rolling CI tests, and documentation consistent with the new Libreswan release while preserving existing behavior and test logic.

### Description

- Updated the default installation version in the four primary setup scripts by changing the `SWAN_VER` assignment to `5.3.2` in `vpnsetup_alpine.sh`, `vpnsetup_amzn.sh`, `vpnsetup_centos.sh`, and `vpnsetup_ubuntu.sh`.
- Updated the current upgrade version assignment to `swan_ver_cur=5.3.2` in the four upgrade scripts under `extras/`: `vpnupgrade_alpine.sh`, `vpnupgrade_amzn.sh`, `vpnupgrade_centos.sh`, and `vpnupgrade_ubuntu.sh`.
- Advanced the rolling-version tests in `.github/workflows/test_set_1.yml` and `.github/workflows/test_set_2.yml` so the previous-version test remains `5.3.1` and the current-version test is `5.3.2`, preserving test order and existing logic.
- Updated the latest-supported-version sentence from `5.3.1` to `5.3.2` in the five README files: `README.md`, `README-ja.md`, `README-ru.md`, `README-zh.md`, and `README-zh-Hant.md`.

### Testing

- Ran `bash -n` on all eight modified shell scripts and all passed: `vpnsetup_alpine.sh`, `vpnsetup_amzn.sh`, `vpnsetup_centos.sh`, `vpnsetup_ubuntu.sh`, `extras/vpnupgrade_alpine.sh`, `extras/vpnupgrade_amzn.sh`, `extras/vpnupgrade_centos.sh`, and `extras/vpnupgrade_ubuntu.sh`.
- Verified the changed-file scope and committed state with `git diff --name-only` / staging checks and confirmed exactly the 15 expected files were modified and staged; `git diff --check` reported no problems.
- Confirmed workflow rolling-version lines with `grep` so each workflow retains one `5.3.1` (previous) and one `5.3.2` (current) test; YAML parsed contextually (no workflow behavior or permissions changed).
- Noted that `actionlint` and `PyYAML` were not available in the environment so workflow linting via `actionlint` and YAML parsing via `PyYAML` were not executed, but focused diffs and contextual checks were performed to validate workflow edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a648b2594ec8324a8267274f3b77fed)